### PR TITLE
Add flag to confirm password when prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # terraform-encrypt
-A simple encrypt program to be used by terraform's external data provider
+
+A simple encrypt program to be used by terraform's external data provider or as a simple CLI tool.
 
 ## Usage
 
@@ -26,14 +27,13 @@ terraform-encrypt decrypt [sourceFiles...] [flags]
 ```
 
 Flags:
+ - `-c`, `--confirm-password`:  Confirm the vault password when prompting.
  - `-o`, `--output string`:     The target file location. Can only be used if a single file is passed. Specify '-' to output to stdout.
  - `-p`, `--password string`:   The vault password. This defaults to the value of environment variable `VAULT_PASSWORD`.
-
 
 ### Using Terraform
 
 Create a json file:
-
 
 ```json
 {
@@ -51,7 +51,6 @@ terraform-encrypt encrypt secret.json
 Read using terraform:
 
 ````hcl
-
 data "external" "secret" {
   program = [
     "terraform-encrypt",
@@ -65,6 +64,4 @@ data "external" "secret" {
 output "result" {
   value = "${data.external.secret.result.message}"
 }
-
 ````
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-encrypt
 
-A simple encrypt program to be used by terraform's external data provider or as a simple CLI tool.
+A simple encrypt program to be used by terraform's external data provider or as a CLI tool.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ terraform-encrypt encrypt secret.json
 
 Read using terraform:
 
-````hcl
+```hcl
 data "external" "secret" {
   program = [
     "terraform-encrypt",
@@ -64,4 +64,4 @@ data "external" "secret" {
 output "result" {
   value = "${data.external.secret.result.message}"
 }
-````
+```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ func init() {
 		rootCmd.AddCommand(cmd)
 		cmd.Flags().StringVarP(&outputFile, "output", "o", "", "The target file location. Can only be used if a single file is passed. Specify '-' to output to stdout.")
 		cmd.Flags().StringVarP(&vaultPassword, "password", "p", "", "The vault password. This defaults to the value of environment variable `VAULT_PASSWORD`.")
-		cmd.Flags().BoolVarP(&confirmPassword, "confirm-password", "c", false, "Confirm the vault password when prompting. Does nothing if `VAULT_PASSWORD` is set.")
+		cmd.Flags().BoolVarP(&confirmPassword, "confirm-password", "c", false, "Confirm the vault password when prompting.")
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"fmt"
-	"os"
 	"errors"
+	"fmt"
+	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
+	"os"
 	"syscall"
 )
 
@@ -14,11 +14,13 @@ func init() {
 		rootCmd.AddCommand(cmd)
 		cmd.Flags().StringVarP(&outputFile, "output", "o", "", "The target file location. Can only be used if a single file is passed. Specify '-' to output to stdout.")
 		cmd.Flags().StringVarP(&vaultPassword, "password", "p", "", "The vault password. This defaults to the value of environment variable `VAULT_PASSWORD`.")
+		cmd.Flags().BoolVarP(&confirmPassword, "confirm-password", "c", false, "Confirm the vault password when prompting. Does nothing if `VAULT_PASSWORD` is set.")
 	}
 }
 
 var outputFile = ""
 var vaultPassword = ""
+var confirmPassword = false
 
 var rootCmd = &cobra.Command{
 	Use:   "terraform-encrypt",
@@ -32,7 +34,7 @@ func Execute() {
 	}
 }
 
-func requireOneInputFile(cmd *cobra.Command, args []string) error {
+func requireOneInputFile(_ *cobra.Command, args []string) error {
 	if outputFile != "" {
 		if len(args) == 0 {
 			return errors.New("provide one input file")
@@ -62,13 +64,25 @@ func findPassword() string {
 
 	// 3. Prompt
 	for result == "" {
-		fmt.Print("Vault Password: ")
-		passwd, err := terminal.ReadPassword(int(syscall.Stdin))
-		if err != nil {
-			panic(err)
+		prompted := promptPassword("Vault Password")
+
+		// Confirm Password
+		if confirmPassword && prompted != promptPassword("Confirm Password") {
+			fmt.Println("Passwords do not match, please try again.")
+			continue
 		}
-		result = string(passwd)
-		fmt.Println()
+
+		result = prompted
 	}
 	return result
+}
+
+func promptPassword(prompt string) string {
+	fmt.Print(prompt + ": ")
+	password, err := terminal.ReadPassword(syscall.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println()
+	return string(password)
 }


### PR DESCRIPTION
When using terraform-encrypt manually from the CLI I found myself decrypting files to make sure if I didn't make a typo in the password. To prevent having to do this I added a flag (`-c` or `--confirm-password`) which will give you a second password prompt and checks if the passwords match.

Another note: maybe this behavior should be reversed so that the confirm is default and there is a `--no-confirm` flag?